### PR TITLE
Update wikify.js

### DIFF
--- a/wikify/wikify.js
+++ b/wikify/wikify.js
@@ -37,13 +37,12 @@
     }
 
     async function getWikiText(uris) {
-
         const rawUri = uris[0];
         const uri = rawUri.split(":")[2]
-        const artistName = await CosmosAsync.get(`https://api.spotify.com/v1/artists/${uri}`)
-        const artistNameTrimmed = (artistName.name).replace(/\s/g, "%20");
-
-        if (artistName != null) {
+        const track = await CosmosAsync.get(`https://api.spotify.com/v1/tracks/${uri}`);
+        if (track != null) {
+            const artistName = track["artists"][0]["name"];
+            const artistNameTrimmed = artistName.replace(/\s/g, "%20");
             try {
                 const wikiInfo = await CosmosAsync.get(`https://${lang}.wikipedia.org/w/api.php?action=query&format=json&prop=extracts%7Cdescription&titles=${artistNameTrimmed}`)
                 //TODO: option to choose local language or english / english fallback? / subcontextmenu to choose?


### PR DESCRIPTION
The wikify.js script does not work in the current spotify version. It seems like the getWikiText function now gets the track ids as the parameter instead of the artist ids. This pull request fixes this issue by using the track api endpoint  :)