### PR TITLE
docs(windows): update spicetify locations

### DIFF
--- a/adblock/README.md
+++ b/adblock/README.md
@@ -7,7 +7,7 @@ Copy `adblock.js` into your [Spicetify](https://github.com/khanhas/spicetify-cli
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/featureshuffle/README.md
+++ b/featureshuffle/README.md
@@ -7,7 +7,7 @@ Copy `FeatureShuffle.js` into your [Spicetify](https://github.com/khanhas/spicet
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/fixEnhance/README.md
+++ b/fixEnhance/README.md
@@ -10,7 +10,7 @@ Copy `fixEnhance.js` into your [Spicetify](https://github.com/khanhas/spicetify-
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/formatColors/README.md
+++ b/formatColors/README.md
@@ -8,7 +8,7 @@ Copy `formatColors.js` into your [Spicetify](https://github.com/khanhas/spicetif
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/phraseToPlaylist/README.md
+++ b/phraseToPlaylist/README.md
@@ -8,7 +8,7 @@ Copy `phraseToPlaylist.js` into your [Spicetify](https://github.com/khanhas/spic
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/songstats/README.md
+++ b/songstats/README.md
@@ -7,7 +7,7 @@ Copy `songstats.js` into your [Spicetify](https://github.com/khanhas/spicetify-c
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```

--- a/wikify/README.md
+++ b/wikify/README.md
@@ -7,7 +7,7 @@ Copy `wikify.js` into your [Spicetify](https://github.com/khanhas/spicetify-cli)
 |------------|-----------------------------------------------------------------------------------|
 | **Linux**      | `~/.config/spicetify/Extensions` or `$XDG_CONFIG_HOME/.config/spicetify/Extensions/` |
 | **MacOS**      | `~/spicetify_data/Extensions` or `$SPICETIFY_CONFIG/Extensions`                      |
-| **Windows**    | `%userprofile%\.spicetify\Extensions\`                                              |
+| **Windows**    | `%appdata%\spicetify\Extensions\`                                              |
 
 After putting the extension file into the correct folder, run the following command to install the extension:
 ```


### PR DESCRIPTION
Update spicetify locations for Windows, in line with the new change in https://github.com/spicetify/spicetify-cli/pull/1801.
