### PR TITLE
feat(adblock): hide topbar upgrade button for all languages

### DIFF
--- a/adblock/adblock.js
+++ b/adblock/adblock.js
@@ -17,7 +17,7 @@
 
     styleSheet.innerHTML =
         `
-    .MnW5SczTcbdFHxLZ_Z8j, .WiPggcPDzbwGxoxwLWFf, .ReyA3uE3K7oEz7PTTnAn, .main-leaderboardComponent-container, .sponsor-container, a.link-subtle.main-navBar-navBarLink.GKnnhbExo0U9l7Jz2rdc, button[title="Upgrade to Premium"], button[aria-label="Upgrade to Premium"], .main-contextMenu-menuItem a[href^="https://www.spotify.com/premium/"] {
+    .MnW5SczTcbdFHxLZ_Z8j, .WiPggcPDzbwGxoxwLWFf, .ReyA3uE3K7oEz7PTTnAn, .main-leaderboardComponent-container, .sponsor-container, a.link-subtle.main-navBar-navBarLink.GKnnhbExo0U9l7Jz2rdc, button[title="Upgrade to Premium"], button[aria-label="Upgrade to Premium"], .main-topBar-UpgradeButton, .main-contextMenu-menuItem a[href^="https://www.spotify.com/premium/"] {
     display: none !important;
     }
     `


### PR DESCRIPTION
`button[title="Upgrade to Premium"], button[aria-label="Upgrade to Premium"]` doesn't work with for non-English localizations